### PR TITLE
Adding a template processing example

### DIFF
--- a/examples/templates.py
+++ b/examples/templates.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+
+import openshift as oc
+
+'''
+This example will scan all the templates, on the cluster, and look specifically for the openshift/nginx-example
+template.  If the template is located, it clears the namespace (to prevent an error when calling 'oc process'),
+updates any template parameter(s), processes the template, and then creates the objects in the current namespace.
+'''
+if __name__ == '__main__':
+    with oc.client_host():
+        templates = oc.selector('templates', all_namespaces=True)
+
+        for template in templates.objects():
+            if template.model.metadata.namespace == 'openshift' and template.model.metadata.name == 'nginx-example':
+                template.model.metadata.namespace = ''
+
+                obj = oc.APIObject(dict_to_model=template.as_dict())
+
+                parameters = {
+                    'NAME': 'my-nginx',
+                }
+
+                processed_template = obj.process(parameters=parameters)
+                obj_sel = oc.create(processed_template)
+
+                for obj in obj_sel.objects():
+                    print('Created: {}/{}'.format(obj.model.kind, obj.model.metadata.name))
+                    print(obj.as_json(indent=4))


### PR DESCRIPTION
This example shows how templates can be searched, updated, processed,
and applied to the cluster.  This initial commit will fail because of
a bug that @psolarvi found and will fix once PR #67 merges.