### PR TITLE
Resolve openshift-restclient-python/issues/383 for module compatibilities

### DIFF
--- a/packages/openshift/__init__.py
+++ b/packages/openshift/__init__.py
@@ -12,7 +12,7 @@ from . import config
 from .ansible import ansible
 
 # Single source for module version
-__VERSION__ = '1.0.6'
+__VERSION__ = __version__ = '1.0.6'
 
 null = None  # Allow scripts to specify null in object definitions
 


### PR DESCRIPTION
Per https://github.com/openshift/openshift-restclient-python/issues/383, I have created a simple solution to make it compatible with openshift restclient. It would be great if you could merge this simple change to make them compatible when both are installed. 
FYI. I have pointed to `main`, but feel free to change if you need to.