### PR TITLE
Change --config arg to --kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ you can specify many default contexts in the environment.
 ### Defaults when invoking `oc`
 Establishing explicit contexts within an application will override these environment defaults.
 - `OPENSHIFT_CLIENT_PYTHON_DEFAULT_OC_PATH` - default path to use when invoking `oc`
-- `OPENSHIFT_CLIENT_PYTHON_DEFAULT_CONFIG_PATH` - default `--config` argument
+- `OPENSHIFT_CLIENT_PYTHON_DEFAULT_CONFIG_PATH` - default `--kubeconfig` argument
 - `OPENSHIFT_CLIENT_PYTHON_DEFAULT_API_SERVER` - default `--server` argument
 - `OPENSHIFT_CLIENT_PYTHON_DEFAULT_CA_CERT_PATH` - default `--cacert` argument
 - `OPENSHIFT_CLIENT_PYTHON_DEFAULT_PROJECT` - default `--namespace` argument

--- a/packages/openshift/action.py
+++ b/packages/openshift/action.py
@@ -230,7 +230,7 @@ def oc_action(context, verb, cmd_args=None, all_namespaces=False, no_namespace=F
         references = {}
 
     if context.get_kubeconfig_path() is not None:
-        cmds.append("--config=%s" % context.get_kubeconfig_path())
+        cmds.append("--kubeconfig=%s" % context.get_kubeconfig_path())
 
     if context.get_api_url() is not None:
         url = context.get_api_url()

--- a/packages/openshift/context.py
+++ b/packages/openshift/context.py
@@ -423,7 +423,7 @@ def api_server(api_url=None, ca_cert_path=None, kubeconfig_path=None):
     Contexts can be nested. The most immediate ancestor cluster context
     will define the API server targeted by an action.
     :param api_url: The oc --server argument to use.
-    :param kubeconfig_path: The oc --config argument to use.
+    :param kubeconfig_path: The oc --kubeconfig argument to use.
     :return: The context object. Can be safely ignored.
     """
 


### PR DESCRIPTION
`--config` is not a known argument to oc.
I'm getting that error whenever I've changed kubeconfig path via this client.