### PR TITLE
Fix default_api_server setter

### DIFF
--- a/packages/openshift/context.py
+++ b/packages/openshift/context.py
@@ -336,7 +336,7 @@ def set_default_kubeconfig_path(path):
 
 
 def set_default_api_url(url):
-    context.default_api_url = url
+    context.default_api_server = url
 
 
 def set_default_project(name):


### PR DESCRIPTION
This PR modifies the `set_default_api_url` function to use `context.default_api_server` instead of `context.default_api_url`.

The `default_api_url` attribute does not exist in the `context` object, and is not used anywhere else in the code. However, `context.default_api_server` is used in `Context#get_api_url`.

## Alternative solution

Modify the `ThreadLocalContext` class to use `api_url` instead of `default_api_server` (to be consistent, we should also rename the `OPENSHIFT_CLIENT_PYTHON_DEFAULT_API_SERVER` variable to `OPENSHIFT_CLIENT_PYTHON_DEFAULT_API_URL`. The  `Context#get_api_url` method should be updated too.

Let me know if you prefer this solution.